### PR TITLE
Updated aws-cdk to 0.21.0

### DIFF
--- a/lib/table-viewer.ts
+++ b/lib/table-viewer.ts
@@ -36,7 +36,7 @@ export class TableViewer extends cdk.Construct {
     super(parent, id);
 
     const handler = new lambda.Function(this, 'Rendered', {
-      code: lambda.Code.directory(path.join(__dirname, 'lambda')),
+      code: lambda.Code.asset(path.join(__dirname, 'lambda')),
       runtime: lambda.Runtime.NodeJS810,
       handler: 'index.handler',
       environment: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,178 +5,199 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assets": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.14.1.tgz",
-      "integrity": "sha512-45Wu/bc6F0rm3RT43iHqow4akKwob7VtbltrvKyyS/vnEq7hasDAjffVQaqMgJQD3ejsTVcwCCapJM0Ma+8VKA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.21.0.tgz",
+      "integrity": "sha512-R76ZXkpNGn/ozqhfkwTGlWceFyCbOLUb1C8hNDm5DSBYg8aF+IR3Tnj6bNCR2KYcTG2j9VwCsStcQ6KbPE7Rlw==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/aws-s3": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1",
-        "@aws-cdk/cx-api": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/aws-s3": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0",
+        "@aws-cdk/cx-api": "^0.21.0"
       }
     },
     "@aws-cdk/aws-apigateway": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-0.14.1.tgz",
-      "integrity": "sha512-B0jIrtumsh3A09bhd2g3zXgV1RZYa3YrfnEEeY+DBeWWqUTtwHK7oqLII/KV+Ynn4/Lgyvugwmko4xUH6f5bLQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-0.21.0.tgz",
+      "integrity": "sha512-RQ8ZAFYWeZ+fCHGyvXH5VTJIziQZtoPVCkCxCSfBhx7TDKgDeEq7/JTJsZtDi5jQh5E4ED76nudILP4Fs84U3g==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/aws-lambda": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/aws-lambda": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.14.1.tgz",
-      "integrity": "sha512-5SNupqo9LC8UbIsPQMX8DXBNYraKBfVpVNIWw0zo6OToweYVsy6YTGysqckpU/HE0yUv/Gm+5m3pJZ7FKw9sFQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.21.0.tgz",
+      "integrity": "sha512-Z2EyHi932fDOhMPSTCfkoXhdfybWNeI+F5iRFF/ecKMbqST8jN7Tyto9Ga+mjPSZp2MizK3XG17Yh9duaExbVw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-autoscaling-common": "^0.21.0",
+        "@aws-cdk/aws-cloudwatch": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-api": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-api/-/aws-autoscaling-api-0.21.0.tgz",
+      "integrity": "sha512-oQNmoX7eJoMSMEyN98aM4yZlm16zovREm/D7Eif+Ba0gF//10MFsB+nmZYZCeSeK91EF/qS7/BL+3QGisVmjnQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.21.0.tgz",
+      "integrity": "sha512-gpDxT4/jRYJBOH2Y5wUngp/9xle6A3GI7UNvENQCvKrhpDm3KZ6q4dYcXQ3kGGKBU2Av9OS8/XSH66OrdmQGbw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.14.1.tgz",
-      "integrity": "sha512-Xlj9xyoRJCSWS1fpkz7G/BR+cgxZxqRD1CFoJesjur5/+DPZmA67yRmfj0VJaQdB/qmwJy3sLaDiFaJ9q1P+Wg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.21.0.tgz",
+      "integrity": "sha512-6tejpgGI7O27qiAIYBLhB3el+4LYb3ktZ8nBWhRmxibv6XrX6Vqqs50ZflDUE6wZ1tyS0qWapF705h7Tzz+QTA==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-codepipeline-api": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-api/-/aws-codepipeline-api-0.14.1.tgz",
-      "integrity": "sha512-9DC6VkrJ254tDA2jJWODI83TycNvFeg0aP1nolNsGq1QmGv9vKrBZw9rZ8Z+VvB3xteBlDfRpp3F1t5HD0PXgA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-api/-/aws-codepipeline-api-0.21.0.tgz",
+      "integrity": "sha512-rUGfCIyyy33hqeNGrFchemiwhPEaoDZkCzPyVhCiRKaeB9wwvaB1A2x4XCs8GKlY8MrNOG5U/yCven0+u8uw2A==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-events": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-dynamodb": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-0.14.1.tgz",
-      "integrity": "sha512-OYk0rypz5Xh6Rg5zEyIOCSMajNVaRWPV8vQuoSXLLwfGl/nHvXkRSSUMxViHGsuT640uTFcEU6YOJhGainz82A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-0.21.0.tgz",
+      "integrity": "sha512-nm2mug4vuKyC0i6pbAA5cWIdaaMdWP1WnEwBfp1RIFCfzh1gMEsE3Q0yW3xMJik2c01YDCKCWJDV5PrOzZAnJg==",
       "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-applicationautoscaling": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.14.1.tgz",
-      "integrity": "sha512-dTfeC3461E7E3TU7noVxOhRMJ0+ItSpN/nM+Go3zYpZCbC+nUHWEfncOh3aHdIhDB73zD+wv+RnTBIGZDeFlJQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.21.0.tgz",
+      "integrity": "sha512-vHCPz2glW/ahXn6jDjOM2FEtk0x0MoHiUgk/8ifisWKP6V0iGn1JQawu+dCzfDgn6e9gwUT+LVuvbx4rs2gt1A==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0",
+        "@aws-cdk/cx-api": "^0.21.0"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.14.1.tgz",
-      "integrity": "sha512-02JcX93uc0CTINz51kB8T8l33sxylEnbUWCXMWO4AocaBLXLo08spIgPHVM9j5UN8flCAKKBywaTKxl4EF9OvA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.21.0.tgz",
+      "integrity": "sha512-dDwXIWm1rbduIvjl6et3lXB01X7hbprJjIwo1PuzpwSQxb0m1B4yZbiCioroSPC/rpvsdIZ9BBSNRfQOudFfJA==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.14.1.tgz",
-      "integrity": "sha512-4LEsXNjrv/jMMUTVtraO70r1n/dC6U5sSUSXFvl2oKt6lrxRAvg8DK9WsSaxFRWKRyrFj/Ll7W/ngGVUa5jHng==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.21.0.tgz",
+      "integrity": "sha512-xtkOY3ZWyY304hzcbV5NczXcyRb6064C6UsnzBEOKeYki+0Tq5XeDdRgDBaHe3l8librQJhhxZoXl8vWtFvLJQ==",
       "requires": {
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.14.1.tgz",
-      "integrity": "sha512-n1qhvr9UUxFSesGiOvR0u8DieuElad6ohCCWyW+yq/cAjn3jsT6faLn0AY/85e/IDsSbxFqSSTevt67TyR1dCg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.21.0.tgz",
+      "integrity": "sha512-fuvbtR6qSpOVs1xQoPiNTm89zSIC3sGd/C8/+Vm1vfi19tvQ5koI5qeA6UBBpsKP5vlZR91brDRCeuWY15LJCw==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.14.1.tgz",
-      "integrity": "sha512-sDegl2b2ZhGjh0b4SSivOa/HofpSJ3IStizQcpKcvQoyTzfOEI8FmZhWKj0fkc3q8dEc7Ev3PmXr8N489WffOQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.21.0.tgz",
+      "integrity": "sha512-UShTISBa3BfGdZk9ej8bGXselo4TxsH3IYBwBBSHy4y4QYnRBr2ViR8GELqOgGU3c2xHe2uFf+m/ZXQmUUDWbw==",
       "requires": {
-        "@aws-cdk/assets": "^0.14.1",
-        "@aws-cdk/aws-cloudwatch": "^0.14.1",
-        "@aws-cdk/aws-codepipeline-api": "^0.14.1",
-        "@aws-cdk/aws-ec2": "^0.14.1",
-        "@aws-cdk/aws-events": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/aws-logs": "^0.14.1",
-        "@aws-cdk/aws-s3": "^0.14.1",
-        "@aws-cdk/aws-s3-notifications": "^0.14.1",
-        "@aws-cdk/aws-sqs": "^0.14.1",
-        "@aws-cdk/aws-stepfunctions": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1",
-        "@aws-cdk/cx-api": "^0.14.1"
+        "@aws-cdk/assets": "^0.21.0",
+        "@aws-cdk/aws-cloudwatch": "^0.21.0",
+        "@aws-cdk/aws-codepipeline-api": "^0.21.0",
+        "@aws-cdk/aws-ec2": "^0.21.0",
+        "@aws-cdk/aws-events": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/aws-logs": "^0.21.0",
+        "@aws-cdk/aws-s3": "^0.21.0",
+        "@aws-cdk/aws-s3-notifications": "^0.21.0",
+        "@aws-cdk/aws-sqs": "^0.21.0",
+        "@aws-cdk/aws-stepfunctions": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0",
+        "@aws-cdk/cx-api": "^0.21.0"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.14.1.tgz",
-      "integrity": "sha512-v1co5LEvFXQg2mypzGn2nRt6MHqnN1lV9Y1HeOAt+YvLiOMPacQ9jh9Liw4TFOUPFhCM5TBlItOULwKKA4cm9g==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.21.0.tgz",
+      "integrity": "sha512-E/Q+YicXWgGZUm6hx3gCcaJpfl/1l7121otr7GMSWbXz0airhM9yeakQKMyI7OJUQZk6EWOJRSkxa63Zaj/8iA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-cloudwatch": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.14.1.tgz",
-      "integrity": "sha512-3EYL61CDg+zdDsEGmN9M16ibVHE5feogobbuSfAheJLSc8JL+F3EIxSMGg1GYJcMNI5bgI6+stoI93a3ABh3DA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.21.0.tgz",
+      "integrity": "sha512-3mqH3CO6pCXV/pT9rIfPqhG0w7nCLE8Mq7oqM82YCP5TXWFjzAIkuNFnGh4AE1/LmEVS0S3ngTQ7dmRF1A+STw==",
       "requires": {
-        "@aws-cdk/aws-codepipeline-api": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/aws-kms": "^0.14.1",
-        "@aws-cdk/aws-s3-notifications": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-codepipeline-api": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/aws-kms": "^0.21.0",
+        "@aws-cdk/aws-s3-notifications": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-s3-notifications": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-0.14.1.tgz",
-      "integrity": "sha512-5M0bI+UOfskWr/w67OktrpMO2wZvO8J5y3aZiBJylFb+Ix55jy8UYEpU2he2Log6ts8FhJYjQhSjzJXHAcYgWg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-0.21.0.tgz",
+      "integrity": "sha512-MdIlaPtqX6PF18vvG+Q7nGR8it7HaHZOqLayEwz9EBgYcT39H6QUMs8gAcPcA1Ch6hJFfE/JXoTr2taVUXNvuw==",
       "requires": {
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.14.1.tgz",
-      "integrity": "sha512-0Ew+zMB86vFhwHqFs/YIbzn6j4mBAckEwXLCrayW6MbzyIiCm/HC++yHtz2zdq7vVVq1RCEUYLK8dxN7pI9dYQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.21.0.tgz",
+      "integrity": "sha512-7mTDi9/JHhXEu6Q2pLHP+OqrjeKRPBlODDp2AIDVZNKzrt8J4Cm3MqytJeIB3q9DZypMoxndleWZIUcDcxRX/Q==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/aws-kms": "^0.14.1",
-        "@aws-cdk/aws-s3-notifications": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-autoscaling-api": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/aws-kms": "^0.21.0",
+        "@aws-cdk/aws-s3-notifications": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/aws-stepfunctions": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-0.14.1.tgz",
-      "integrity": "sha512-yJwyg3hJ+LLvIU1kFvp/ePw1Q6C3tVaWzKYIvwRo1WxZTgG78mRyIqW2YizHkqq5TgJFG6Ot+lmLjU8t/LYqqg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-0.21.0.tgz",
+      "integrity": "sha512-dg9hIEX/r32WADyFNfefm6eWnL9AeuNasswRXEQOr3Ap5nAFsJWGOEwUYqpSV1GX7JkXfGBLPJ4gzBSPEEmOew==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.14.1",
-        "@aws-cdk/aws-events": "^0.14.1",
-        "@aws-cdk/aws-iam": "^0.14.1",
-        "@aws-cdk/cdk": "^0.14.1"
+        "@aws-cdk/aws-cloudwatch": "^0.21.0",
+        "@aws-cdk/aws-events": "^0.21.0",
+        "@aws-cdk/aws-iam": "^0.21.0",
+        "@aws-cdk/cdk": "^0.21.0"
       }
     },
     "@aws-cdk/cdk": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.14.1.tgz",
-      "integrity": "sha512-jvaQnUv3TBlJn36XpHtVnUrUaHOrOkJkNTpJAE8ag3CeD6bTg4FVSY2BdOnEiCeTYnd6cwrG9NWp+sVJke2k6A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.21.0.tgz",
+      "integrity": "sha512-Oq3jhRlumyWpJqG5xEXODmLG9GYP9oRCelnREOmnJ2qT/BQLF3pK1P8xruhHchn18FKCmKCRwzjHnvApdtVanw==",
       "requires": {
-        "@aws-cdk/cx-api": "^0.14.1",
+        "@aws-cdk/cx-api": "^0.21.0",
         "js-base64": "^2.4.5",
         "json-diff": "^0.3.1"
       },
@@ -211,7 +232,7 @@
           "bundled": true
         },
         "js-base64": {
-          "version": "2.4.9",
+          "version": "2.5.0",
           "bundled": true
         },
         "json-diff": {
@@ -230,9 +251,9 @@
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.14.1.tgz",
-      "integrity": "sha512-2PMLbe3yU0RVefFKWm+9kVzvzv//CGM2WuzmdAMrTTLVWzMU6dkAnu7NE2GB/xG3nQIFPkhBoEb6aWrP0VqjTw=="
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.21.0.tgz",
+      "integrity": "sha512-R6/SkHeF0XLCjjO6BTGERzW597UwhUm080/KT5FfmkevYq/9uZkZW0APFbXtuwOVFcWaehHb4ENVJPOkaMaPFA=="
     },
     "@types/node": {
       "version": "10.12.0",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "typescript": "^3.1.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^0.14.1",
-    "@aws-cdk/aws-dynamodb": "^0.14.1",
-    "@aws-cdk/aws-lambda": "^0.14.1",
-    "@aws-cdk/cdk": "^0.14.1"
+    "@aws-cdk/aws-apigateway": "^0.21.0",
+    "@aws-cdk/aws-dynamodb": "^0.21.0",
+    "@aws-cdk/aws-lambda": "^0.21.0",
+    "@aws-cdk/cdk": "^0.21.0"
   }
 }


### PR DESCRIPTION
Current version of aws-cdk is incompatible with this 0.14.1 . Specifically this part of workshop https://cdkworkshop.com/50-table-viewer.html does not work.

Whole workshop works again with this update!