### PR TITLE
Change lambda runtime from Node 8 to Node 12

### DIFF
--- a/lib/table-viewer.ts
+++ b/lib/table-viewer.ts
@@ -37,7 +37,7 @@ export class TableViewer extends cdk.Construct {
 
     const handler = new lambda.Function(this, 'Rendered', {
       code: lambda.Code.asset(path.join(__dirname, 'lambda')),
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_12_X,
       handler: 'index.handler',
       environment: {
         TABLE_NAME: props.table.tableName,

--- a/test/__snapshots__/viewer.test.js.snap
+++ b/test/__snapshots__/viewer.test.js.snap
@@ -128,7 +128,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },


### PR DESCRIPTION
The NodeJS 8.X runtime is no longer supported for new Lambda functions as of 2020-01-06

*Issue #, if available:*
N/A

*Description of changes:*
* Change the Lambda runtime to Node 12.X

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
